### PR TITLE
Surrogate models based on ensemble of PyTorch models

### DIFF
--- a/src/millefeuille/optimise.py
+++ b/src/millefeuille/optimise.py
@@ -3,7 +3,7 @@ import time
 from botorch.optim import optimize_acqf, optimize_acqf_mixed
 
 from .state import State
-from .surrogate import BaseGPSurrogate
+from .surrogate import BaseSurrogate
 
 DEFAULT_NUM_RESTARTS = 1
 DEFAULT_RAW_SAMPLES = 256
@@ -53,7 +53,7 @@ def suggest_next_locations(
 ):
     # Check inputs
     assert isinstance(state, State)
-    assert isinstance(surrogate, BaseGPSurrogate)
+    assert isinstance(surrogate, BaseSurrogate)
 
     # Train the model
     if verbose:

--- a/src/millefeuille/surrogate.py
+++ b/src/millefeuille/surrogate.py
@@ -1,15 +1,21 @@
+import copy
 from abc import ABC, abstractmethod
+from typing import Dict, List
 
 import numpy as np
 import numpy.typing as npt
 import torch
+import torch.nn as nn
 from botorch.fit import fit_gpytorch_mll
 from botorch.models import SingleTaskGP
+from botorch.models.ensemble import EnsembleModel
 from gpytorch.constraints import Interval
 from gpytorch.kernels import MaternKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.module import Module
+from torch import Tensor
+from torch.utils.data import DataLoader, TensorDataset, random_split
 
 from .kernel import ModifiedSingleTaskMultiFidelityGP
 from .state import State
@@ -21,28 +27,11 @@ Defines a number of surrogate models
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 dtype = torch.double
 
-# Default GP hyperparameters
-DEFAULT_NOISE_INTERVAL = [1e-8, 1e-5]
-DEFAULT_LENGTHSCALE_INTERVAL = [0.005, 4.0]
 
-
-class BaseGPSurrogate(ABC):
+class BaseSurrogate(ABC):
     """
     Abstract base class for all surrogate models in mille-feuille.
     """
-
-    def __init__(self):
-        self.model = None
-        self.mean_module = None
-        self.likelihood = None
-        self.state_dicts = None
-
-    @abstractmethod
-    def init(self, state: State):
-        """
-        Train the surrogate model on the current optimisation state.
-        """
-        pass
 
     @abstractmethod
     def fit(self, state: State):
@@ -73,6 +62,55 @@ class BaseGPSurrogate(ABC):
         assert X_torch.min() >= 0.0 and X_torch.max() <= 1.0 and torch.all(torch.isfinite(Y_torch))
 
         return X_torch, Y_torch
+
+    @abstractmethod
+    def eval(self):
+        """
+        Set internal models to evaluation mode (PyTorch).
+        """
+        pass
+
+    @abstractmethod
+    def save(self, filepath: str):
+        """
+        Save trained model to disk.
+        """
+        pass
+
+    @abstractmethod
+    def load(self, filepath: str, eval=True):
+        """
+        Load a saved model.
+        """
+        pass
+
+
+##################################################
+############### Gaussian Processes ###############
+##################################################
+
+# Default GP hyperparameters
+DEFAULT_NOISE_INTERVAL = [1e-8, 1e-5]
+DEFAULT_LENGTHSCALE_INTERVAL = [0.005, 4.0]
+
+
+class BaseGPSurrogate(BaseSurrogate, ABC):
+    """
+    Abstract base class for all GP surrogate models in mille-feuille.
+    """
+
+    def __init__(self):
+        self.model = None
+        self.mean_module = None
+        self.likelihood = None
+        self.state_dicts = None
+
+    @abstractmethod
+    def init_GP_model(self, state: State):
+        """
+        Train the surrogate model on the current optimisation state.
+        """
+        pass
 
     def update_state_dicts(self):
         """
@@ -119,7 +157,7 @@ class BaseGPSurrogate(ABC):
 
 
 class SingleFidelityGPSurrogate(BaseGPSurrogate):
-    def init(
+    def init_GP_model(
         self,
         state: State,
         mean_module: Module | None = None,
@@ -146,7 +184,7 @@ class SingleFidelityGPSurrogate(BaseGPSurrogate):
         self.update_state_dicts()
 
     def fit(self, state: State, approx_mll=False, **kwargs):
-        self.init(state, self.mean_module, **kwargs)
+        self.init_GP_model(state, self.mean_module, **kwargs)
 
         mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
 
@@ -195,3 +233,208 @@ class MultiFidelityGPSurrogate(BaseGPSurrogate):
             std = np.sqrt(var)
         mean, std = state.inverse_transform_Y(mean, std)
         return {fid: {"mean": mean[:, fid], "std": std[:, fid]} for fid in range(state.fidelity_domain.num_fidelities)}
+
+
+##################################################
+################ Ensemble Models #################
+##################################################
+
+
+class BasePyTorchModel(nn.Module, ABC):
+    @property
+    @abstractmethod
+    def optimiser(self):
+        pass
+
+    @property
+    @abstractmethod
+    def scheduler(self):
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def from_state_dict(state_dict):
+        """
+        Creates a instance of BasePyTorchModel from a given state_dict
+        """
+        pass
+
+
+class EnsemblePyTorchModel(EnsembleModel):
+    model_base_class: type[BasePyTorchModel]
+    models: List[type[BasePyTorchModel]]
+    starting_state_dicts: Dict
+    _num_outputs: int
+    ensemble_size: int
+    training_epochs: int
+    batch_size: int
+    train_test_split: List[float]
+    loss: type[nn.Module]
+    reset_before_training: bool
+
+    def __init__(
+        self,
+        ensemble_size: int,
+        model_base_class: type[BasePyTorchModel],
+        ensemble_state_dicts: Dict,
+        training_epochs: int,
+        batch_size: int,
+        train_test_split: List[float],
+        loss: type[nn.Module],
+        reset_before_training: bool,
+    ):
+        super().__init__()
+        self.model_base_class = model_base_class
+        if ensemble_state_dicts is None:
+            self.models = [self.model_base_class() for _ in range(ensemble_size)]
+        else:
+            assert ensemble_size == len(ensemble_state_dicts)
+            self.models = [self.model_base_class.from_state_dict(sd) for _, sd in ensemble_state_dicts.items()]
+
+        self.starting_state_dicts = {}
+        for i, m in enumerate(self.models):
+            self.starting_state_dicts[f"model_{i}_state_dict"] = copy.copy(m.state_dict(keep_vars=True))
+
+        self.ensemble_size = ensemble_size
+        self._num_outputs = 1
+
+        self.training_epochs = training_epochs
+        self.batch_size = batch_size
+        self.train_test_split = train_test_split
+        self.loss = loss
+        self.reset_before_training = reset_before_training
+
+    def get_state_dicts(self):
+        state_dicts = {}
+        for i, m in enumerate(self.models):
+            state_dicts[f"model_{i}_state_dict"] = copy.copy(m.state_dict(keep_vars=True))
+        return state_dicts
+
+    def update_state_dicts(self, state_dicts):
+        self.starting_state_dicts = state_dicts
+        self.reset_models()
+
+    def reset_models(self):
+        self.models = [self.model_base_class.from_state_dict(sd) for _, sd in self.starting_state_dicts.items()]
+
+    def fit(self, X: Tensor, y: Tensor) -> None:
+        if self.reset_before_training:
+            self.reset_models()
+
+        dataset = TensorDataset(X, y)
+
+        for m in self.models:
+            model = m.model
+            optimiser = m.optimiser
+            scheduler = m.scheduler
+
+            model.train()
+            train_dataset, _ = random_split(dataset, self.train_test_split)
+            train_loader = DataLoader(train_dataset, batch_size=self.batch_size, shuffle=True)
+            for _ in range(self.training_epochs):
+                for X_train, y_train in train_loader:
+                    y_pred = model(X_train)
+                    optimiser.zero_grad()
+                    tloss = self.loss(y_pred, y_train)
+                    tloss.backward()
+                    optimiser.step()
+
+                scheduler.step()
+
+            model.eval()
+
+    def forward(self, X: Tensor) -> Tensor:
+        ys = torch.stack([m.model(X) for m in self.models], dim=1)
+        return ys.unsqueeze(-2)
+
+
+class BaseEnsemblePyTorchSurrogate(BaseSurrogate, ABC):
+    """
+    Abstract base class for all ensemble of PyTorch model surrogates in mille-feuille.
+    """
+
+    def __init__(
+        self,
+        ensemble_size: int,
+        model_base_class: type[BasePyTorchModel],
+        training_epochs: int,
+        batch_size: int,
+        pretrained_file: str | None = None,
+        train_test_split: List[float] | None = None,
+        loss: type[nn.Module] | None = None,
+        reset_before_training: bool = True,
+    ):
+        self.model_base_class = model_base_class
+        self.ensemble_size = ensemble_size
+
+        if train_test_split is None:
+            train_test_split = [0.7, 0.3]
+
+        if loss is None:
+            loss = nn.MSELoss()
+
+        if pretrained_file is None:
+            ensemble_state_dicts = None
+        else:
+            checkpoint = torch.load(pretrained_file, weights_only=False, map_location=device)
+            ensemble_state_dicts = {}
+            for k, v in checkpoint.items():
+                ensemble_state_dicts[k] = v
+
+        self.model = EnsemblePyTorchModel(
+            ensemble_size,
+            model_base_class,
+            ensemble_state_dicts,
+            training_epochs,
+            batch_size,
+            train_test_split,
+            loss,
+            reset_before_training,
+        )
+        self.ensemble_state_dicts = self.model.get_state_dicts()
+
+    def eval(self):
+        """
+        Set internal models to evaluation mode.
+        """
+        for model in self.model.models:
+            model.eval()
+
+    def save(self, filepath: str):
+        """
+        Save trained models' state dicts to disk.
+        """
+        self.ensemble_state_dicts = self.model.get_state_dicts()
+        torch.save(self.ensemble_state_dicts, filepath)
+
+    def load(self, filepath: str, eval=True):
+        """
+        Load saved models' state dicts.
+        """
+        checkpoint = torch.load(filepath, weights_only=False, map_location=device)
+        self.ensemble_state_dicts = {}
+        for k, v in checkpoint.items():
+            self.ensemble_state_dicts[k] = v
+
+        self.model.update_state_dicts(self.ensemble_state_dicts)
+
+        if eval:
+            self.eval()
+
+
+class SingleFidelityEnsembleSurrogate(BaseEnsemblePyTorchSurrogate):
+    def fit(self, state: State):
+        X_torch, Y_torch = self.get_XY(state)
+
+        self.model.fit(X_torch, Y_torch)
+
+    def predict(self, state: State, Xs):
+        Xs_unit = state.transform_X(Xs)
+        test_X = torch.tensor(Xs_unit, dtype=dtype, device=device)
+        with torch.no_grad():
+            post = self.model.posterior(test_X)
+            mean = post.mean.cpu().numpy().reshape(-1, 1)
+            var = post.variance.cpu().numpy().reshape(-1, 1)
+            std = np.sqrt(var)
+        mean, std = state.inverse_transform_Y(mean, std)
+        return {"mean": mean, "std": std}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ class PythonForresterFunction(PythonSimulator):
     """
 
     def f(self, Xs):
-        ys = (6 * Xs - 2) ** 2 * np.sin(12 * Xs + 4)
+        ys = (6 * Xs - 2) ** 2 * np.sin(12 * Xs - 4)
         return ys
 
     def ABC_values(self, Ss):
@@ -56,7 +56,7 @@ class LowFidelityForresterMean(Mean):
         self.register_parameter(name="raw_constant", parameter=torch.nn.Parameter(torch.zeros(1)))
 
     def f(self, Xs):
-        ys = (6 * Xs - 2) ** 2 * torch.sin(12 * Xs + 4)
+        ys = (6 * Xs - 2) ** 2 * torch.sin(12 * Xs - 4)
         return ys
 
     def ABC_values(self, Ss):

--- a/tests/test_exe/cxxmain.cpp
+++ b/tests/test_exe/cxxmain.cpp
@@ -13,7 +13,7 @@ using json = nlohmann::json;
 // Forrester test function (scalar variant)
 // ---------------------------------------------------------------------------
 inline double forrester(double x) {
-    return std::pow(6.0 * x - 2.0, 2) * std::sin(12.0 * x + 4.0);
+    return std::pow(6.0 * x - 2.0, 2) * std::sin(12.0 * x - 4.0);
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_exe/fmain.f90
+++ b/tests/test_exe/fmain.f90
@@ -45,7 +45,7 @@ program forrester_test
         real :: x
         real :: y
 
-        y = (6 * x - 2) ** 2 * sin(12 * x + 4)
+        y = (6 * x - 2) ** 2 * sin(12 * x - 4)
 
     end subroutine forrester
 

--- a/tests/test_optimise.py
+++ b/tests/test_optimise.py
@@ -44,7 +44,7 @@ def test_optimise_singlefidelity_GP(singlefidelitysample, batch_size, generate_a
     state = State(ForresterDomain, Is, Xs, Ys)
 
     surrogate = SingleFidelityGPSurrogate()
-    surrogate.init(state)
+    surrogate.init_GP_model(state)
 
     acq_function = generate_acq_function(surrogate, state)
 

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -17,6 +17,7 @@ from .conftest import ForresterDomain, LowFidelityForresterMean, PythonForrester
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 dtype = torch.double
 
+
 @pytest_cases.fixture(params=[5, 10, 20])
 def ntrain(request):
     return request.param
@@ -129,12 +130,12 @@ class NNSurrogate(BasePyTorchModel):
             nn.Tanh(),
             nn.Linear(8, 8, dtype=dtype, device=device),
             nn.Tanh(),
-            nn.Linear(8, 1, dtype=dtype, device=device)
-            )
+            nn.Linear(8, 1, dtype=dtype, device=device),
+        )
 
     @property
     def optimiser(self):
-        return torch.optim.Adam(self.model.parameters(), lr = 1e-2)
+        return torch.optim.Adam(self.model.parameters(), lr=1e-2)
 
     @property
     def scheduler(self):
@@ -178,8 +179,11 @@ def test_singlefidelity_NNEnsemble(testXs):
     surrogate.save("test.pth")
 
     second_surrogate = SingleFidelityEnsembleSurrogate(
-        ensemble_size=ensemble_size, model_base_class=NNSurrogate, training_epochs=nepochs, batch_size=batch_size,
-        pretrained_file = "test.pth"
+        ensemble_size=ensemble_size,
+        model_base_class=NNSurrogate,
+        training_epochs=nepochs,
+        batch_size=batch_size,
+        pretrained_file="test.pth",
     )
     os.remove("test.pth")
 

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -5,13 +5,17 @@ import warnings
 import numpy as np
 import pytest
 import pytest_cases
+import torch
+import torch.nn as nn
 from botorch.exceptions.warnings import OptimizationWarning
 from millefeuille.initialise import generate_initial_sample
 from millefeuille.state import State
-from millefeuille.surrogate import SingleFidelityGPSurrogate
+from millefeuille.surrogate import BasePyTorchModel, SingleFidelityEnsembleSurrogate, SingleFidelityGPSurrogate
 
 from .conftest import ForresterDomain, LowFidelityForresterMean, PythonForresterFunction, sampler
 
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+dtype = torch.double
 
 @pytest_cases.fixture(params=[5, 10, 20])
 def ntrain(request):
@@ -47,14 +51,13 @@ def test_singlefidelity_GP(singlefidelitysample, testXs):
     state = State(ForresterDomain, Is, Xs, Ys)
 
     surrogate = SingleFidelityGPSurrogate()
-    surrogate.init(state)
     surrogate.fit(state)
     testYs = surrogate.predict(state, testXs)
 
     surrogate.save("test.pth")
 
     second_surrogate = SingleFidelityGPSurrogate()
-    second_surrogate.init(state)
+    second_surrogate.init_GP_model(state)
     second_surrogate.load("test.pth", eval=True)
     os.remove("test.pth")
     second_testYs = second_surrogate.predict(state, testXs)
@@ -80,7 +83,7 @@ def test_singlefidelity_mean_module_GP(singlefidelitysample, testXs):
     mean_surrogate = SingleFidelityGPSurrogate()
     mean_module = LowFidelityForresterMean(output_scaler)
     initial_mean_state_dict = mean_module.state_dict()
-    mean_surrogate.init(state, mean_module=mean_module)
+    mean_surrogate.init_GP_model(state, mean_module=mean_module)
     mean_surrogate.fit(state)
     testYs = mean_surrogate.predict(state, testXs)
 
@@ -99,15 +102,87 @@ def test_singlefidelity_mean_module_GP(singlefidelitysample, testXs):
                 )
 
     error_surrogate = SingleFidelityGPSurrogate()
-    error_surrogate.init(state)
+    error_surrogate.init_GP_model(state)
     # Check error is raised when don't use mean module
     with pytest.raises(Exception) as _:  # noqa
         error_surrogate.load("test.pth", eval=True)
 
     second_surrogate = SingleFidelityGPSurrogate()
-    second_surrogate.init(state, mean_module=LowFidelityForresterMean(state.Y_scaler))
+    second_surrogate.init_GP_model(state, mean_module=LowFidelityForresterMean(state.Y_scaler))
     second_surrogate.load("test.pth", eval=True)
     os.remove("test.pth")
+    second_testYs = second_surrogate.predict(state, testXs)
+
+    assert np.isclose(testYs["mean"], second_testYs["mean"]).all(), (
+        "Mean predictions diverged between saved and loaded surrogate model"
+    )
+    assert np.isclose(testYs["std"], second_testYs["std"]).all(), (
+        "Std. dev. predictions diverged between saved and loaded surrogate model"
+    )
+
+
+class NNSurrogate(BasePyTorchModel):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Linear(1, 8, dtype=dtype, device=device),
+            nn.Tanh(),
+            nn.Linear(8, 8, dtype=dtype, device=device),
+            nn.Tanh(),
+            nn.Linear(8, 1, dtype=dtype, device=device)
+            )
+
+    @property
+    def optimiser(self):
+        return torch.optim.Adam(self.model.parameters(), lr = 1e-2)
+
+    @property
+    def scheduler(self):
+        class do_nothing(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def step(self):
+                pass
+
+        return do_nothing()
+
+    @staticmethod
+    def from_state_dict(state_dict):
+        model = NNSurrogate()
+        model.load_state_dict(state_dict)
+        return model
+
+
+@pytest.mark.unit
+def test_singlefidelity_NNEnsemble(testXs):
+    ntrain_NN = 50
+    batch_size = 32
+    nepochs = 400
+    ensemble_size = 10
+
+    Is = np.arange(ntrain_NN)
+    Xs, _ = generate_initial_sample(ForresterDomain, sampler, ntrain_NN)
+    f = PythonForresterFunction()
+    Ys = f(Is, Xs)
+
+    state = State(ForresterDomain, Is, Xs, Ys)
+
+    surrogate = SingleFidelityEnsembleSurrogate(
+        ensemble_size=ensemble_size, model_base_class=NNSurrogate, training_epochs=nepochs, batch_size=batch_size
+    )
+
+    surrogate.fit(state)
+    testYs = surrogate.predict(state, testXs)
+
+    surrogate.save("test.pth")
+
+    second_surrogate = SingleFidelityEnsembleSurrogate(
+        ensemble_size=ensemble_size, model_base_class=NNSurrogate, training_epochs=nepochs, batch_size=batch_size,
+        pretrained_file = "test.pth"
+    )
+    os.remove("test.pth")
+
     second_testYs = second_surrogate.predict(state, testXs)
 
     assert np.isclose(testYs["mean"], second_testYs["mean"]).all(), (


### PR DESCRIPTION
Basic framework for using ensemble of PyTorch models as surrogates, user needs to define this model within the follow abstract class mf.surrogate.BasePyTorchModel

- Added test of pre-trained model loading
- Fixed error in definition of Forrester functions (oops!)